### PR TITLE
Polish: wait for reboot only if necessary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
   async: 1
   poll: 0
   ignore_errors: true
+  register: wtd_system_update_reboot
   when:
     ( wtd_system_update_list.results | join("") | search("kernel") or 
     wtd_system_update_list.results | join("") | search("glibc") ) and
@@ -24,5 +25,5 @@
   wait_for_connection:
     timeout: 600
     delay: 20  
-  when: wtd_system_update_autoreboot == True
+  when: wtd_system_update_autoreboot == True and wtd_system_update_reboot.changed
 ...


### PR DESCRIPTION
# wait for reboot only if necessary
Run the task "Wait for reboot" only if a reboot was triggered.

## Reference
 - Resolves: #2 