### PR TITLE
Fix: ansible-galaxy minus to underscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: 
+python:
   - "2.7"
   - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while_true_do.system-update
+  - ln -s  $PWD ../while_true_do.system_update
 
 # Run the tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 ---
 language: python
-python:
+python: 
   - "2.7"
   - "3.6"
 
 sudo: false
 
-# Install ansible
+# Install python-pip
 addons:
   apt:
     packages:
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.system-update
+  - ln -s  $PWD ../while_true_do.system-update
 
 # Run the tests
 script:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Updating a system is very common. Having a role, which helps for initial updates
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/system-update)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/system_update)
 
 ```
-ansible-galaxy install while_true_do.system-update
+ansible-galaxy install while_true_do.system_update
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-system-update)

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Updating a system is very common. Having a role, which helps for initial updates
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do/system-update)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/system-update)
 
 ```
-ansible-galaxy install while-true-do.system-update
+ansible-galaxy install while_true_do.system-update
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-system-update)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-system-update.git while-true-do.system-update
+git clone https://github.com/while-true-do/ansible-role-system-update.git while_true_do.system-update
 ```
 
 ## Requirements
@@ -56,7 +56,7 @@ Simple Example:
 ```
 - hosts: servers
   roles:
-    - { role: while-true-do.system-update }
+    - { role: while_true_do.system-update }
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ansible-galaxy install while_true_do.system_update
 Install from [Github](https://github.com/while-true-do/ansible-role-system-update)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-system-update.git while_true_do.system-update
+git clone https://github.com/while-true-do/ansible-role-system-update.git while_true_do.system_update
 ```
 
 ## Requirements
@@ -56,7 +56,7 @@ Simple Example:
 ```
 - hosts: servers
   roles:
-    - { role: while_true_do.system-update }
+    - { role: while_true_do.system_update }
 ```
 
 ## Testing

--- a/docs/COMMIT_TEMPLATE.md
+++ b/docs/COMMIT_TEMPLATE.md
@@ -32,7 +32,7 @@ Further paragraphs come after blank lines, if needed.
  - Bullet points are okay, too.
  - A hyphen or asterisk is used for the bullet, preceded by a single space and can
    be wrapped around.
-   
+
  - Resolves: #12
  - See also: #33, #44
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 | While True Do Contribution Guidelines
 
 
-This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/docs/) to check the latest version.
+This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md) to check the latest version.
 
 ## Welcome
 
@@ -17,7 +17,7 @@ In this document you can find some guidance, how you can take care of bugs, subm
 -   [Submit Changes and Pull Requests](#Submit-Changes-and-Pull-Requests)
 -   [Documentation](#Documentation)
 -   [Testing](#Testing)
-  
+
 ## Resources
 
 -   Documents: <https://github.com/while-true-do/community/>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 dependencies: [ ]
 
 galaxy_info:
+  role_name: system_update
   author: while-true-do.org
   description: A role to install updates or security updates.
   company: while-true-do.org

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while_true_do.system-update
+    - while_true_do.system_update

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.system-update
+    - while_true_do.system-update

--- a/update-meta-files.sh
+++ b/update-meta-files.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Description:
-#   update-skeleton.sh is a very minimal script to update the skeleton with 
-#   some additional content from while-true-do.org. It will not remove files, 
+#   update-skeleton.sh is a very minimal script to update the skeleton with
+#   some additional content from while-true-do.org. It will not remove files,
 #   you created. Replacement must be acknowledged.
 
 function usage {
@@ -90,7 +90,7 @@ function update_all {
 }
 
 while getopts 'admst' opts; do
-  
+
   case "${opts}" in
     a) update_all ;;
     d) update_docs ;;


### PR DESCRIPTION
# Fix: ansible-galaxy minus to underscore

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

## Reference

 - Resolves:
