### PR TITLE
 Rework: use generic role for reboot tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ git clone https://github.com/while-true-do/ansible-role-system-update.git while_
 Used Modules:
 
 -   [command_module](https://docs.ansible.com/ansible/latest/modules/command_module.html)
--   [wait_for_connection_module](https://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html)
 
 Distribution specific modules:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Distribution specific modules:
 
 ## Dependencies
 
-None.
+-   [reboot](https://github.com/while-true-do/ansible-role-reboot)
 
 ## Role Variables
 

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -22,4 +22,4 @@ https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md
 
 ### Attachments
 
-<!-- Please attach everything, what can help to understand the issue like screenshots, code snippets, error codes, animations, etc. -->
+<!-- Please attach everything, that can help to understand the issue like screenshots, code snippets, error codes, animations, etc. -->

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: [ ]
+dependencies:
+  - while_true_do.reboot
 
 galaxy_info:
   role_name: system_update
@@ -9,7 +10,7 @@ galaxy_info:
   github_branch: master
   license: BSD
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.3
 
   platforms:
   - name: EL

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+# from Ansible Galaxy
+- src: while_true_do.reboot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,20 +3,10 @@
 - name: Include "{{ ansible_distribution }}" tasks
   include_tasks: "{{ ansible_distribution }}.yml"
 
-- name: Reboot Machine
-  shell: sleep 2 && shutdown -r now "Reboot triggered from while-true-do.system-update"
-  async: 1
-  poll: 0
-  ignore_errors: True
-  become: yes
-  when: wtd_system_update_needs_reboot is defined and
-        wtd_system_update_autoreboot == True and
-        wtd_system_update_needs_reboot.rc == 1
-
-- name: Wait for Reboot
-  wait_for_connection:
-    timeout: 6000
-    delay: 20
+- name: Activate reboot handler
+  command: "true"
+  notify:
+    - Reboot Machine
   when: wtd_system_update_needs_reboot is defined and
         wtd_system_update_autoreboot == True and
         wtd_system_update_needs_reboot.rc == 1


### PR DESCRIPTION
#  Rework: use generic role for reboot tasks

- Use while_true_do.reboot handlers to perform a reboot.
If this role and another role will now use handlers they are now
triggered only once.

## Reference
 - Resolves: #12 