### PR TITLE
Fix: role for Fedora distribution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,14 @@
   poll: 0
   ignore_errors: True
   become: yes
-  when: wtd_system_update_autoreboot == True and wtd_system_update_needs_reboot.rc == 1
+  when: wtd_system_update_needs_reboot is defined and
+        wtd_system_update_autoreboot == True and
+        wtd_system_update_needs_reboot.rc == 1
 
 - name: Wait for Reboot
   wait_for_connection:
     timeout: 6000
     delay: 20
-  when: wtd_system_update_autoreboot == True and wtd_system_update_needs_reboot.rc == 1
+  when: wtd_system_update_needs_reboot is defined and
+        wtd_system_update_autoreboot == True and
+        wtd_system_update_needs_reboot.rc == 1


### PR DESCRIPTION
# Fix: role for Fedora distribution

wtd_system_update_needs_reboot is currently not defined for Fedora.
To get it working check for the reboot tasks if this variable is defined.

## Reference

 - Resolves: #10 
 - See also: #33, #44

## (Optional) People

<!--
@mentions of somebody who was involved or should be involved.
@mentions of the person or team responsible for reviewing proposed changes.
-->
